### PR TITLE
make all microsoft-* providers deprecated

### DIFF
--- a/providers.js
+++ b/providers.js
@@ -90,22 +90,6 @@ module.exports = [
         maintainers: [],
       },
       {
-        slug: 'Microsoft-Azure', name: 'Microsoft Azure',
-        maintainers: [],
-      },
-      {
-        slug: 'Microsoft-Graph', name: 'Microsoft Graph',
-        maintainers: [],
-      },
-      {
-        slug: 'Microsoft-Live', name: 'Microsoft Live',
-        maintainers: [],
-      },
-      {
-        slug: 'Microsoft-TeamService', name: 'Microsoft TeamService',
-        maintainers: [],
-      },
-      {
         slug: 'Naver', name: 'Naver',
         maintainers: [],
       },
@@ -653,6 +637,22 @@ module.exports = [
   },
   {
     name: 'Deprecated', collapsable: true, providers: [
+      {
+        slug: 'Microsoft-Azure', name: 'Microsoft Azure',
+        maintainers: [],
+      },
+      {
+        slug: 'Microsoft-Graph', name: 'Microsoft Graph',
+        maintainers: [],
+      },
+      {
+        slug: 'Microsoft-Live', name: 'Microsoft Live',
+        maintainers: [],
+      },
+      {
+        slug: 'Microsoft-TeamService', name: 'Microsoft TeamService',
+        maintainers: [],
+      },
     ],
   },
 ]


### PR DESCRIPTION
azure graph live and teamservice are all deprecated in favor of the "microsoft"
https://github.com/SocialiteProviders/Providers/issues/425#issuecomment-632965047