### PR TITLE
Fix naming of service pr0gramm

### DIFF
--- a/providers.js
+++ b/providers.js
@@ -126,7 +126,7 @@ module.exports = [
         maintainers: [],
       },
       {
-        slug: 'pr0gramm', name: 'pr0gramm',
+        slug: 'Pr0gramm', name: 'pr0gramm',
         maintainers: ['Tschucki'],
       },
       {

--- a/providers.js
+++ b/providers.js
@@ -126,7 +126,7 @@ module.exports = [
         maintainers: [],
       },
       {
-        slug: 'Pr0gramm', name: 'Pr0gramm',
+        slug: 'pr0gramm', name: 'pr0gramm',
         maintainers: ['Tschucki'],
       },
       {


### PR DESCRIPTION
The website is called pr0gramm with a lowercase `p`.
Examples can be seen in its FAQ: https://pr0gramm.com/faq/others/facts

You might want to change the capitalization of the corresponding repository too, as capitalization should have no impact.