### PR TITLE
Fix slug of Start.gg

### DIFF
--- a/providers.js
+++ b/providers.js
@@ -286,7 +286,7 @@ module.exports = [
         maintainers: [],
       },
       {
-        slug: 'Start.gg', name: 'Start.gg',
+        slug: 'StartGg', name: 'Start.gg',
         maintainers: ['nickbeen'],
       },
       {


### PR DESCRIPTION
The Socialite Providers website currently loads the page for Start.gg as https://socialiteproviders.com/Start.gg/ which does not correctly render the README.md file.

This PR changes the slug from `Start.gg` to `StartGg` to be in line with the repository name which seems to be the problem. This is the only provider that contains a dot in it's name.