### PR TITLE
Move EduID provider to education section

### DIFF
--- a/providers.js
+++ b/providers.js
@@ -34,10 +34,6 @@ module.exports = [
         maintainers: [],
       },
       {
-        slug: 'EduID', name: 'EduID',
-        maintainers: ['raphaelportmann'],
-      },
-      {
         slug: 'Facebook', name: 'Facebook',
         maintainers: [],
       },
@@ -336,6 +332,10 @@ module.exports = [
       {
         slug: 'Dataporten', name: 'Dataporten',
         maintainers: [],
+      },
+      {
+        slug: 'EduID', name: 'EduID',
+        maintainers: ['raphaelportmann'],
       },
       {
         slug: 'App.net', name: 'AppNet',


### PR DESCRIPTION
Didn't realize, that there are different sections when I initally added the provider.

Moved it to the correct section.