### PR TITLE
Update providers.js (move SURFconext)

### DIFF
--- a/providers.js
+++ b/providers.js
@@ -182,10 +182,6 @@ module.exports = [
         maintainers: [],
       },
       {
-        slug: 'SURFconext', name: 'SURFconext',
-        maintainers: [],
-      },
-      {
         slug: 'Telegram', name: 'Telegram',
         maintainers: ['Max13'],
       },
@@ -367,6 +363,10 @@ module.exports = [
       },
       {
         slug: 'StockTwits', name: 'StockTwits',
+        maintainers: [],
+      },
+      {
+        slug: 'SURFconext', name: 'SURFconext',
         maintainers: [],
       },
       {


### PR DESCRIPTION
This moves SURFconext to the Education / Careers section.

SURF is the NREN (National research and education network) of the Netherlands. Almost all institutions connected to SURFconext are research or education institutions, so the Education / Careers section is more fitting for this provider.

More info:
https://www.surf.nl/en/services/surfconext