### PR TITLE
Add klarna provider to the docs

### DIFF
--- a/providers.js
+++ b/providers.js
@@ -684,6 +684,10 @@ module.exports = [
         maintainers: ['m1guelpf'],
       },
       {
+        slug: 'Klarna', name: 'Klarna',
+        maintainers: ['taher435'],
+      },
+      {
         slug: 'MediaCube', name: 'MediaCube',
         maintainers: [],
       },


### PR DESCRIPTION
Adding provider for Klarna in [this PR](https://github.com/SocialiteProviders/Providers/pull/1297). Adding documentation for the new provider. 

This should be merged after the provider PR is merged so that we don't render a blank screen on the documentation.