### PR TITLE
Add Calendly provider

### DIFF
--- a/providers.js
+++ b/providers.js
@@ -434,6 +434,10 @@ module.exports = [
         maintainers: [],
       },
       {
+        slug: 'Calendly', name: 'Calendly',
+        maintainers: ['paulchrisluke'],
+      },
+      {
         slug: 'CampaignMonitor', name: 'CampaignMonitor',
         maintainers: [],
       },


### PR DESCRIPTION
Adding Calendly provider to the website following the provider addition in SocialiteProviders/Providers#1265.

This PR adds Calendly to the providers list in the Productivity/Business section.