### PR TITLE
fix: strip YAML frontmatter from fetched provider READMEs

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,5 +1,13 @@
 const categories = require('../../providers')
 
+// Provider READMEs may carry YAML frontmatter (e.g. `category`) used by the
+// tooling in SocialiteProviders/Providers. Strip it before the content is
+// prepended to, since frontmatter is only parsed when it starts at line 1 —
+// otherwise the `---` is read as a setext underline and the keys render as a
+// heading on the page.
+const stripFrontmatter = md =>
+  typeof md === 'string' ? md.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, '') : md
+
 const generatedSidebar = categories.map(cat => {
   return {
     title: cat.name,
@@ -60,7 +68,7 @@ module.exports = {
         let content
         try {
           const res = await axios.get(`https://raw.githubusercontent.com/SocialiteProviders/${provider.slug}/master/README.md`)
-          content = res.data
+          content = stripFrontmatter(res.data)
           console.log(`Fetched readme for ${provider.slug}`)
         } catch (e) {
           console.error(`Failed to fetch readme for ${provider.slug}: ${e}`)


### PR DESCRIPTION
Groundwork for adding a `category` frontmatter key to provider READMEs, so the Providers repo can generate the `providers.js` entry automatically.

Frontmatter is only parsed when it starts on line 1, but `additionalPages` prepends `<ProviderHeader>` (and the deprecation banner) to every fetched README. That pushes the opening `---` down, so it gets parsed as Markdown instead: the `---` becomes a setext underline, the component line renders as an `<h2>`, and the keys show up as a visible heading on the page.

This strips the frontmatter block at fetch time, before anything is prepended.

Verified against a VuePress 1.8.2 build — with the fix, a README carrying `category:` renders with no leakage, and the deprecation banner and provider header are unaffected. The regex only matches a block at the very start of the file, so horizontal rules, setext headings, and READMEs opening with raw HTML are left alone.

No-op until a README actually has frontmatter.
