### PR TITLE
feat: add Epic Games and Logto to the provider list

### DIFF
--- a/providers.js
+++ b/providers.js
@@ -337,6 +337,10 @@ module.exports = [
         slug: 'Zitadel', name: 'Zitadel',
         maintainers: ['tbhaxor'],
       },
+      {
+        slug: 'Logto', name: 'Logto',
+        maintainers: [],
+      },
     ],
   },
   {
@@ -411,6 +415,10 @@ module.exports = [
       },
       {
         slug: 'Vatsim', name: 'VATSIM',
+        maintainers: [],
+      },
+      {
+        slug: 'EpicGames', name: 'Epic Games',
         maintainers: [],
       },
     ],


### PR DESCRIPTION
Adds the two providers merged in SocialiteProviders/Providers#1458 (Epic Games) and #1456 (Logto).

Both landed before their READMEs carried the `category` frontmatter, so the sync workflow skipped them.

| Slug | Name | Category |
| --- | --- | --- |
| `EpicGames` | Epic Games | Gaming |
| `Logto` | Logto | Social / Platform |

Generated with `tools/sync-website.php` rather than by hand, and both READMEs were confirmed to fetch so the pages render.

A follow-up on the Providers repo adds the missing frontmatter to these two READMEs so they stay consistent with the automated path.
