### PR TITLE
docs: refresh contribute page to match Providers repo

### DIFF
--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -6,16 +6,63 @@ title: Contribute
 
 ## Creating a Provider
 
-* Create the provider class
-* Create a listener/handler
-* Create a composer.json file and add <em>socialiteproviders/manager</em> (<a href="https://github.com/SocialiteProviders/Manager">See the manager package.</a>) in the "require" section.
-* If using OAuth1 you need to also create a server class.
-* Generate documentation for the provider by running `docgen.php` in the `tools` folder. (and customise if required).
-* Add the provider to the `monorepo-builder.yml` subtree split config in the repository root.
+The <a href="https://github.com/SocialiteProviders/Providers">Providers</a> repo ships a scaffolding tool that writes every file a provider needs:
 
-To speed up the creation of your provider you can use the <a href="https://github.com/SocialiteProviders/Generators">generator</a>.
+```bash
+php tools/make-provider.php
+```
 
-Look at the already created <a href="#providers">providers</a> and the <a href="https://github.com/SocialiteProviders/Manager">Manager</a> package for inspiration.
+It asks for the provider name, driver alias, OAuth version, display name, category, whether the
+provider uses PKCE, and any extra config keys. From those answers it writes `Provider.php`,
+`<Name>ExtendSocialite.php`, `composer.json` and `README.md` under `src/<Name>/`, plus a
+`Server.php` for OAuth1 providers and an optional test suite under `tests/<Name>/`.
+
+Every answer also has a flag, so it can run unattended:
+
+```bash
+php tools/make-provider.php --name=Frappe --oauth=2 --category=Misc --no-tests
+```
+
+Once it has run, there are three things the tool can't do for you:
+
+* Fill in the `TODO`s in `Provider.php` against the provider's own OAuth documentation.
+* Link that documentation in the `README.md`. Reviewers ask for it every time.
+* Add yourself to `authors` in the provider's `composer.json`.
+
+The generated `README.md` is a starting point, not the finished article — customise it for
+anything specific to the provider, such as required scopes or non-obvious config.
+
+You don't need to register the provider anywhere. Splitting to a standalone repo is automatic:
+new `src/*` directories are detected from the merge commit and split out on release.
+
+Look at the already created <a href="#providers">providers</a> and the
+<a href="https://github.com/SocialiteProviders/Manager">Manager</a> package for inspiration.
+
+::: tip Building a provider for one app?
+The <a href="https://github.com/SocialiteProviders/Generators">Generators</a> package is a
+different tool for a different job. It installs an Artisan command into a Laravel application and
+generates a provider inside <em>that</em> app. Use it when you need a one-off provider you don't
+intend to publish; use `make-provider.php` when you're contributing a provider here.
+:::
+
+## Category
+
+Each provider's `README.md` needs a `category` key in its frontmatter, which is what files it on
+this site:
+
+```markdown
+---
+category: Misc
+---
+```
+
+It must be one of:
+
+`Social / Platform`, `Gaming`, `Education / Career`, `Productivity / Business`,
+`Government / University`, `Payments`, `Music`, `Misc`
+
+Anything else is rejected when the provider is merged, so a near-miss like `Business` will fail.
+The scaffolding tool validates your answer, but a README edited by hand gets no such check.
 
 ## Submitting a new provider
 
@@ -25,7 +72,7 @@ Send new provider pull requests to the <a href="https://github.com/SocialiteProv
 
 Below is an example handler. You need to add the fully qualified class name to the `listen[]` in the `EventServiceProvider`.
 
-* <a href="https://laravel.com/docs/8.x/events">See also the Laravel docs about events</a>
+* <a href="https://laravel.com/docs/events">See also the Laravel docs about events</a>
 * `providername` is the name of the provider such as `meetup`.
 * You will need to change the namespaces to match your vendor and package name.
 
@@ -36,17 +83,20 @@ use SocialiteProviders\Manager\SocialiteWasCalled;
 
 class ProviderNameExtendSocialite
 {
-    public function handle(SocialiteWasCalled $socialiteWasCalled)
+    public function handle(SocialiteWasCalled $socialiteWasCalled): void
     {
-        $socialiteWasCalled->extendSocialite('providername', 'Your\Name\Space\ProviderName');
+        $socialiteWasCalled->extendSocialite('providername', Provider::class);
     }
 }
 ```
 
+The alias passed to `extendSocialite()` is used verbatim as the key in `config/services.php`, so a
+provider registered as `epic-games` reads the `epic-games` key — not `epic_games`.
+
 ## Resources
 
 * <a href="https://medium.com/@morrislaptop/adding-auth-providers-to-laravel-socialite-ca0335929e42">See this article on Medium</a> about creating a new provider
-* <a href="https://laravel.com/docs/8.x/events">Laravel docs on events</a>
+* <a href="https://laravel.com/docs/events">Laravel docs on events</a>
 
 ## Overriding a Built-in Provider
 
@@ -54,9 +104,28 @@ You can easily override a built-in laravel/socialite provider by creating a new 
 
 ## Tests
 
-If we have tests in the repo (currently and foreseeably only the <a href="https://github.com/SocialiteProviders/Manager">Manager</a> package)
-you need to have tests cover any changes submitted in a pull request.  We currently use PHPUnit and Mockery for our test suite.
+Tests aren't mandatory for a new provider, but they're wired up and welcome. Create
+`tests/<Provider>/`, extend `SocialiteProviders\Tests\TestCase` and implement `provider()` to return
+your provider class. CI picks the suite up automatically and runs it against the providers a pull
+request touches — there's no workflow to edit.
+
+Tests live at the repository root rather than under `src/`, because each provider is split to its own
+repo on the `src/<Provider>` prefix; tests kept alongside the provider would ship in the published
+package.
+
+`TestCase` provides `makeProvider()`, `makeRequest()`, `makeHttpClient()` and `fixture()` for
+stubbing responses, plus `makeRequestWithSession()` for providers that use PKCE.
+
+We use PHPUnit and Mockery for the test suite.
 
 ## Style
 
-Run PHP-CS-Fixer on your machine and put a .styleci.yml into the repository with preset: symfony to make sure that pull requests and merges follow the <a href="http://symfony.com/doc/current/contributing/code/standards.html">Symfony Coding Standards</a>.
+Code style is handled by <a href="https://laravel.com/docs/pint">Pint</a>, configured in `pint.json`
+at the repository root with the `laravel` preset:
+
+```bash
+vendor/bin/pint
+```
+
+Style is fixed automatically once a pull request is merged, so a PR that only fails on formatting
+isn't a blocker.


### PR DESCRIPTION
The contribute page had drifted from the Providers repo. Most of it described a workflow that no longer exists.

## Wrong before this PR

| Page said | Reality |
|---|---|
| Run `docgen.php` in `tools` | Deleted in Providers#1474 |
| Add the provider to `monorepo-builder.yml` | No such file — splitting is automatic |
| Add a `.styleci.yml` with `preset: symfony` | Style is Pint, `pint.json`, `laravel` preset |
| Tests exist "only in Manager" | Providers has had a suite since #1472 |
| Hand-create the provider class and listener | `php tools/make-provider.php` writes all of it |

## Changes

- **Creating a Provider** rewritten around `tools/make-provider.php`, with the three manual follow-ups it can't do (fill the TODOs, link the OAuth docs, add yourself to `authors`). Drops the `monorepo-builder.yml` and `docgen.php` bullets.
- **Generators** reframed rather than removed — it builds a provider inside a Laravel app, which is a different job from contributing one here. The page previously implied they were interchangeable.
- **Category** — new section. The README needs `category:` frontmatter from a fixed list, or `sync-website.php` rejects the provider on merge. This already bit Providers#1473 (`Business`).
- **Tests** — how to add one: `tests/<Provider>/`, extend `TestCase`, implement `provider()`. Notes why tests live at the root (`split.sh` splits on `src/<Provider>`) and lists the helpers.
- **Style** — Pint instead of PHP-CS-Fixer/StyleCI; style is auto-fixed on merge.
- **Handler example** — `Provider::class` instead of the string FQCN, Laravel links off 8.x, and a note that the alias is the config key verbatim (`epic-games`, not `epic_games`).

Every command on the page was run against a clean checkout. The site itself wasn't built locally, so the `::: tip` container is worth a glance in the deploy preview.
