### PR TITLE
fix: point search at the current Algolia index

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -25,8 +25,10 @@ module.exports = {
 
   themeConfig: {
     algolia: {
-      apiKey: '0e200be675661f6f31335298fa29523b',
-      indexName: 'socialiteproviders'
+      appId: 'A7BSU83FZM',
+      apiKey: '92e81691e183f041adb7d541c5061689',
+      indexName: 'socialiteproviders',
+      algoliaOptions: { hitsPerPage: 10 },
     },
     providerCount: categories.reduce((count, cat) => count + cat.providers.length, 0),
     sidebarDepth: 1,


### PR DESCRIPTION
Searching for "Adobe" returns nothing, even though the provider has a page. The same query works in the Algolia dashboard.

## Cause

The site is querying a **stale index on the legacy `BH4D9OD16A` app**, not the one the crawler now writes to.

| | legacy `BH4D9OD16A` | current `A7BSU83FZM` |
|---|---|---|
| total records | 1129 | 2010 |
| hits for `adobe` | **0** | 7 |

The old index stopped being crawled, so every provider added since is missing from search. `ado` on the old index returns Admitad — which is exactly what the widget shows.

It looked like a DocSearch version problem, but it isn't: VuePress 1.x bundles docsearch.js v2 while the dashboard shows the v3 snippet, and that mismatch is real but harmless here. The index being wrong is the whole bug.

## Changes

- **Adds `appId`.** It was missing entirely, and docsearch.js falls back to the legacy app without it — so the key alone wouldn't have switched indexes.
- **Updates `apiKey`** to the current app's search key.
- **Raises `hitsPerPage` to 10.** The default of 5 is too small for 9 categories: v2 groups by category, so a query matching several of them can push a valid result out of the list.

## Verification

Both indexes queried directly over the REST API. On the current index, with the `lang:en-US` facet filter VuePress injects (`AlgoliaSearchBox.vue` line 58), `adobe` returns 7 hits — the site's `<html lang>` is `en-US`, so the facet matches. Confirmed `appId` reaches docsearch.js via the theme's `Object.assign` spread.

Not verified locally: VuePress 1.x doesn't install cleanly under Yarn 4 here, so this wants a look at the deploy preview before merge.
