### PR TITLE
feat: add OpenID Connect provider under a new Generic category

### DIFF
--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -66,8 +66,11 @@ category: Misc
 
 It must be one of:
 
-`Social / Platform`, `Gaming`, `Education / Career`, `Productivity / Business`,
+`Generic`, `Social / Platform`, `Gaming`, `Education / Career`, `Productivity / Business`,
 `Government / University`, `Payments`, `Music`, `Misc`
+
+`Generic` is for providers that implement a protocol rather than a single service, such as
+OpenID Connect.
 
 Anything else is rejected when the provider is merged, so a near-miss like `Business` will fail.
 The scaffolding tool validates your answer, but a README edited by hand gets no such check.

--- a/providers.js
+++ b/providers.js
@@ -1,5 +1,13 @@
 module.exports = [
   {
+    name: 'Generic', providers: [
+      {
+        slug: 'openid-connect', name: 'OpenID Connect',
+        maintainers: ['adrum', 'atymic'],
+      },
+    ],
+  },
+  {
     name: 'Social / Platform', providers: [
       {
         slug: 'Adobe', name: 'Adobe',

--- a/providers.js
+++ b/providers.js
@@ -2,7 +2,7 @@ module.exports = [
   {
     name: 'Generic', providers: [
       {
-        slug: 'openid-connect', name: 'OpenID Connect',
+        slug: 'OpenIDConnect', name: 'OpenID Connect',
         maintainers: ['adrum', 'atymic'],
       },
     ],


### PR DESCRIPTION
Lists the new OpenID Connect provider, merged in SocialiteProviders/Providers#1475 and split to [SocialiteProviders/OpenIDConnect](https://github.com/SocialiteProviders/OpenIDConnect).

Maintainers: @adrum, @atymic.

## New `Generic` category

OpenID Connect implements a protocol rather than wrapping a single service, so it doesn't sit naturally next to Auth0, Okta or Keycloak in `Social / Platform` — it's the thing those are built on. This adds a `Generic` section, pinned above the other categories.

Two knock-on effects, both intended:

- `Generic` becomes a valid `category:` value in the Providers repo, since `sync-website.php` reads the section names out of this file.
- The category list on the contribute page is updated to match, with a line explaining what `Generic` is for.

## Why this needs a manual PR

#1475 carried the `new-provider` label, so `sync-website.php` should have listed the provider automatically. It didn't, because `src/OpenIDConnect/README.md` has no `category:` frontmatter — the sync rejects providers without one. Worth adding there so the automation isn't skipped next time.

## Notes

- The slug is `OpenIDConnect`, matching the split repo. `openid-connect` also resolves, but only through a GitHub rename redirect — both names point at the same repo, canonically `OpenIDConnect`.
- The repo has no README frontmatter, so nothing is stripped from the rendered page.
- `providers.js` parses clean: 10 categories, 277 providers. The fetch URL the build uses (`.../OpenIDConnect/master/README.md`) returns 200.
