### PR TITLE
feat: add Frappe / ERPNext to the provider list

### DIFF
--- a/providers.js
+++ b/providers.js
@@ -622,6 +622,10 @@ module.exports = [
         maintainers: [],
       },
       {
+        slug: 'Frappe', name: 'Frappe / ERPNext',
+        maintainers: ['kayedspace'],
+      },
+      {
         slug: 'GettyImages', name: 'GettyImages',
         maintainers: [],
       },


### PR DESCRIPTION
Adds the **Frappe / ERPNext** provider from SocialiteProviders/Providers#1473 to the provider list under **Productivity / usiness**.                                                                                                                                                                                

Listed myself as maintainer.  