### PR TITLE
feat: add Steady to the provider list

### DIFF
--- a/providers.js
+++ b/providers.js
@@ -989,6 +989,10 @@ module.exports = [
         slug: 'Zettle', name: 'Zettle',
         maintainers: [],
       },
+      {
+        slug: 'Steady', name: 'Steady',
+        maintainers: [],
+      },
     ],
   },
   {


### PR DESCRIPTION
Added automatically from https://github.com/SocialiteProviders/Providers/commit/47679c144d6b831ae900d235f044bf243119890c.

* `Steady` — Steady (Payments)